### PR TITLE
003-cytopia Tree

### DIFF
--- a/.github/workflows/task-003.yml
+++ b/.github/workflows/task-003.yml
@@ -15,6 +15,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@master
 
+      - name: Install requirements
+        run: |
+          sudo apt-get update
+          sudo apt-get install tree
+
+      - name: Print environment
+        run: |
+          env
+
       - name: Run
         run: |
           make test-003 "ARGS=${job}"

--- a/003/cytopia/tree.py
+++ b/003/cytopia/tree.py
@@ -3,12 +3,149 @@
 
 import argparse
 import os
+import re
 import sys
+from functools import cmp_to_key
+
+
+# -------------------------------------------------------------------------------------------------
+# GLOBALS
+# -------------------------------------------------------------------------------------------------
+
+# Compiled regex to check for alphanumerics
+IS_ALPHANUM = re.compile(r'[a-zA-Z0-9]')
+
+# Keep track of num of dirs and files
+CNT_FILES = 0
+CNT_DIRS = 0
+
+
+# -------------------------------------------------------------------------------------------------
+# SORT FUNCTIONS
+# -------------------------------------------------------------------------------------------------
+
+
+def sort_default(a, b):
+    """
+    Sort dirs/files by default tree sorting.
+
+    returns 0 if elements are equal
+    returns -1 if a is smaller than b
+    returns 1 if a is greater than b
+    """
+    # Both characters are alphanumeric
+    if IS_ALPHANUM.match(a[0]) and IS_ALPHANUM.match(b[0]):
+        if a[0].lower() < b[0].lower():
+            return -1
+        elif a[0].lower() > b[0].lower():
+            return 1
+    # Only a is alphanumeric
+    elif IS_ALPHANUM.match(a[0]) and IS_ALPHANUM.match(b[0]) is None:
+        if len(b) > 1:
+            return sort_default(a, b[1:])
+        return 1
+    # Only b is alphanumeric
+    elif IS_ALPHANUM.match(a[0]) is None and IS_ALPHANUM.match(b[0]):
+        if len(a) > 1:
+            return sort_default(a[1:], b)
+        return -1
+
+    # Nothing matches, compare the next character if it has it
+    if len(a) == 1 and len(b) == 1:
+        return -1 if ord(a[0]) <= ord(b[0]) else 0
+    elif len(a) == 1 and len(b) > 1:
+        return -1
+    elif len(a) > 1 and len(b) == 1:
+        return 1
+    else:
+        # Remove first from both strings char and recurse
+        return sort_default(a[1:], b[1:])
+
+
+# -------------------------------------------------------------------------------------------------
+# Tree Functions
+# -------------------------------------------------------------------------------------------------
+
+
+def retrieve_files(path, hidden=False, dir_only=False):
+    """Retrieve files/dirs from a path based on criteria."""
+    # Get files
+    files = os.listdir(path=path)
+
+    # Remove hidden files/dirs (anything that starts with dot)
+    if not hidden:
+        files = list(filter(lambda x: True if not x.startswith('.') else False, files))
+    # Remove files and only keep directories
+    if dir_only:
+        files = list(filter(lambda x, path=path: os.path.isdir(os.path.join(path, x)), files))
+    # Sort files
+    files = sorted(files, key=cmp_to_key(sort_default))
+
+    return files
+
+
+def print_tree(path, hidden=False, dir_only=False, level=None, curr_level=1, prevs=[]):
+    """Get files recursively."""
+    global CNT_DIRS
+    global CNT_FILES
+    # Get files and sort alphabetically
+    files = retrieve_files(path, hidden=hidden, dir_only=dir_only)
+    total = len(files)
+    last = total - 1  # last index
+
+    for idx, f in enumerate(files):
+        abs_path = os.path.join(path, f)
+
+        # Print previous recursion round delimiter
+        for delim in prevs:
+            print(delim, end='')
+
+        # If it is the last element on the current level, then
+        # print the sign that shows the last element
+        if idx == last:
+            print('%s' % ('└── '), end='')
+        # If more elements are to come, then we print the sign,
+        # that has continuation
+        else:
+            print('%s' % ('├── '), end='')
+        print('%s' % f)
+
+        if level is None or level > curr_level:
+            if os.path.isdir(abs_path):
+                CNT_DIRS += 1
+                # Build delimiter for next recursion round
+                tmp = prevs.copy()
+
+                # If it is not the last element on this level, (there is an element after it)
+                # we need to print the dashes until the element is reached
+                if idx < last:
+                    tmp.append('│   ')
+                # If it is the last element on this level, we do not print
+                # the continuation line, but just empty spaces.
+                else:
+                    tmp.append('    ')
+
+                print_tree(abs_path, hidden, dir_only, level, curr_level+1, tmp)
+            else:
+                CNT_FILES += 1
 
 
 # -------------------------------------------------------------------------------------------------
 # COMMAND LINE ARGUMENTS
 # -------------------------------------------------------------------------------------------------
+
+
+def _args_check_level(value):
+    """Check if level is correct."""
+    try:
+        intval = int(value)
+    except Exception:
+        raise argparse.ArgumentTypeError("%s must be an integer." % value)
+
+    if intval < 1:
+        raise argparse.ArgumentTypeError("%s must be greater than 0." % value)
+
+    return int(value)
 
 
 def _args_check_path(value):
@@ -33,7 +170,12 @@ def get_args():
         "-d", "--dir", action="store_true", required=False, help="List directories only."
     )
     parser.add_argument(
-        "-L", "--level", metavar="lvl", required=False, help="Max display depth of directory tree."
+        "-L",
+        "--level",
+        metavar="lvl",
+        type=_args_check_level,
+        required=False,
+        help="Max display depth of directory tree."
     )
     parser.add_argument(
         "-H",
@@ -60,7 +202,19 @@ def get_args():
 def main():
     """Start the program."""
     args = get_args()
-    print(args)
+
+    print(args.path)
+    print_tree(args.path, args.all, args.dir, args.level)
+
+    if args.dir:
+        print("\n%i %s" % (CNT_DIRS, 'directory' if CNT_DIRS == 1 else 'directories'))
+    else:
+        print("\n%i %s, %i %s" % (
+            CNT_DIRS,
+            'directory' if CNT_DIRS == 1 else 'directories',
+            CNT_FILES,
+            'file' if CNT_FILES == 1 else 'files',
+        ))
 
 
 if __name__ == "__main__":

--- a/003/cytopia/tree.py
+++ b/003/cytopia/tree.py
@@ -26,15 +26,15 @@ def get_size(path, do_print=False):
         return ""
     # size in bytes
     size = int(os.path.getsize(path))
-
-    yotta = 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024
-    zetta = 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024
-    exa = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
-    peta = 1024 * 1024 * 1024 * 1024 * 1024
-    tera = 1024 * 1024 * 1024 * 1024
-    giga = 1024 * 1024 * 1024
-    mega = 1024 * 1024
+    # sizes in unites
     kilo = 1024
+    mega = kilo * 1024
+    giga = mega * 1024
+    tera = giga * 1024
+    peta = tera * 1024
+    exa = peta * 1024
+    zetta = exa * 1024
+    yotta = zetta * 1024
 
     if size >= yotta:
         result = size / yotta

--- a/003/cytopia/tree.py
+++ b/003/cytopia/tree.py
@@ -2,7 +2,21 @@
 """Python tree implementation."""
 
 import argparse
+import os
 import sys
+
+
+# -------------------------------------------------------------------------------------------------
+# COMMAND LINE ARGUMENTS
+# -------------------------------------------------------------------------------------------------
+
+
+def _args_check_path(value):
+    """Check if path exists."""
+    if not os.path.isdir(value):
+        raise argparse.ArgumentTypeError("%s directory does not exist." % value)
+
+    return value
 
 
 def get_args():
@@ -28,6 +42,13 @@ def get_args():
         required=False,
         help="Print the size of each file but in a more human readable way.",
     )
+    parser.add_argument(
+        "path",
+        type=_args_check_path,
+        nargs="?",
+        default=".",
+        help="address to listen or connect to",
+    )
     return parser.parse_args()
 
 
@@ -39,6 +60,7 @@ def get_args():
 def main():
     """Start the program."""
     args = get_args()
+    print(args)
 
 
 if __name__ == "__main__":

--- a/003/cytopia/tree.py
+++ b/003/cytopia/tree.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Python tree implementation."""
+
+import argparse
+import sys
+
+
+def get_args():
+    """Retrieve command line arguments."""
+    parser = argparse.ArgumentParser(description="Python tree implementation.")
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        required=False,
+        help="All files are printed. By default tree does not print hidden files.",
+    )
+    parser.add_argument(
+        "-d", "--dir", action="store_true", required=False, help="List directories only."
+    )
+    parser.add_argument(
+        "-L", "--level", metavar="lvl", required=False, help="Max display depth of directory tree."
+    )
+    parser.add_argument(
+        "-H",
+        "--human",
+        action="store_true",
+        required=False,
+        help="Print the size of each file but in a more human readable way.",
+    )
+    return parser.parse_args()
+
+
+# -------------------------------------------------------------------------------------------------
+# MAIN ENTRYPOINT
+# -------------------------------------------------------------------------------------------------
+
+
+def main():
+    """Start the program."""
+    args = get_args()
+
+
+if __name__ == "__main__":
+    # Catch Ctrl+c and exit without error message
+    try:
+        main()
+    except KeyboardInterrupt:
+        print()
+        sys.exit(1)

--- a/003/cytopia/tree.py
+++ b/003/cytopia/tree.py
@@ -27,6 +27,7 @@ def get_size(path, do_print=False):
     # size in bytes
     size = int(os.path.getsize(path))
 
+    yotta = 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024
     zetta = 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024
     exa = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
     peta = 1024 * 1024 * 1024 * 1024 * 1024
@@ -35,6 +36,9 @@ def get_size(path, do_print=False):
     mega = 1024 * 1024
     kilo = 1024
 
+    if size >= yotta:
+        result = size / yotta
+        unit = "Y"
     if size >= zetta:
         result = size / zetta
         unit = "Z"

--- a/tests/003.sh
+++ b/tests/003.sh
@@ -20,7 +20,11 @@ create_dirs() {
 	mkdir -p "${prefix}/001/cytopia/.aaa"
 	mkdir -p "${prefix}/001/001"
 	mkdir -p "${prefix}/001/002"
+	mkdir -p "${prefix}/001/_001"
 	mkdir -p "${prefix}/001/.001"
+	mkdir -p "${prefix}/001/.0.01"
+	mkdir -p "${prefix}/001/.0.02"
+	mkdir -p "${prefix}/001/_002"
 	mkdir -p "${prefix}/001/.002"
 	mkdir -p "${prefix}/001/.cytopia/aaa"
 	mkdir -p "${prefix}/001/.cytopia/_mmm"
@@ -98,8 +102,8 @@ fi
 
 ABS_PATH="${SCRIPTPATH}/../${EXCERCISE}/${1}/${FILENAME}"
 if [ ! -f "${ABS_PATH}" ]; then
-	echo "Error, file not found: '${ABS_PATH}'"
-	exit 1
+	echo "Tree not available: '${ABS_PATH}'"
+	exit 0
 fi
 
 


### PR DESCRIPTION
# Python `tree` imlplementation

Python implementation of the unix [tree](https://linux.die.net/man/1/tree) command.

## Usage
```bash
$ ./003/cytopia/tree.py -h
usage: tree.py [-h] [-a] [-d] [-L lvl] [-H]

Python tree implementation.

optional arguments:
  -h, --help           show this help message and exit
  -a, --all            All files are printed. By default tree does not print
                       hidden files.
  -d, --dir            List directories only.
  -L lvl, --level lvl  Max display depth of directory tree.
  -H, --human          Print the size of each file but in a more human
                       readable way.
```

## Benchmark

```bash
# Original tree implementation
$ tree ~/

real    0m10.510s
user    0m3.280s
sys     0m2.588s
```

```bash
# Python rewrite
$ tree.py ~/

real    0m13.523s
user    0m9.418s
sys     0m3.921s
```